### PR TITLE
Create models to parse API response

### DIFF
--- a/frontend/src/Api.js
+++ b/frontend/src/Api.js
@@ -1,3 +1,5 @@
+import ProgramTrace from "./models/ProgramTrace";
+
 class RawApi {
   static async _send(method, path, body = null) {
     const opts = {
@@ -27,7 +29,8 @@ class RawApi {
 }
 
 export default class Api {
-  static getCodeTrace(lang, code) {
-    return RawApi.get(`wsgi-bin/wsgi_backend.py?lang=${encodeURIComponent(lang)}&code=${encodeURIComponent(code)}`);
+  static async getCodeTrace(lang, code) {
+    const path = `wsgi-bin/wsgi_backend.py?lang=${encodeURIComponent(lang)}&code=${encodeURIComponent(code)}`;
+    return new ProgramTrace(await RawApi.get(path));
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,7 @@ class App extends Component {
     return (
       <div className="App">
         <header className="App-header">
-          <img src={"/img/logo.svg"} className="App-logo" alt="logo" />
+          <img src="/img/logo.svg" className="App-logo" alt="logo" />
           <h1 className="App-title">Welcome to SeePlusPlus</h1>
         </header>
         <p className="App-intro">

--- a/frontend/src/Utils.js
+++ b/frontend/src/Utils.js
@@ -1,0 +1,22 @@
+export default class Utils {
+  static arrayOfType(Type, array, producer) {
+    return array.map(element => {
+      if (element instanceof Type) {
+        return element;
+      } else {
+        return producer ? producer(element) : new Type(element);
+      }
+    });
+  }
+
+  static mapValues(Type, obj, producer) {
+    const result = {};
+    Object.keys(obj).forEach(key => {
+      const element = obj[key];
+      if (!(element instanceof Type)) {
+        result[key] = producer ? producer(element) : new Type(element);
+      }
+    });
+    return result;
+  }
+}

--- a/frontend/src/models/ProgramTrace.js
+++ b/frontend/src/models/ProgramTrace.js
@@ -1,0 +1,9 @@
+import TraceStep from "./TraceStep";
+import Utils from "../Utils";
+
+export default class ProgramTrace {
+  constructor({ code, trace }) {
+    this.code = code;
+    this.trace = Utils.arrayOfType(TraceStep, trace);
+  }
+}

--- a/frontend/src/models/StackFrame.js
+++ b/frontend/src/models/StackFrame.js
@@ -1,0 +1,18 @@
+import Utils from "../Utils";
+import Variable from "./Variable";
+
+export default class StackFrame {
+  constructor({ frame_id, func_name, is_highlighted, is_parent, is_zombie, line, parent_frame_id_list, unique_hash,
+                encoded_locals, ordered_varnames }) {
+    this.frameId = frame_id;
+    this.funcName = func_name;
+    this.isHighlighted = is_highlighted;
+    this.line = line;
+    this.isParent = is_parent;
+    this.isZombie = is_zombie;
+    this.parentFrameIdList = parent_frame_id_list;
+    this.uniqueHash = unique_hash;
+    this.encoded_locals = Utils.mapValues(Variable, encoded_locals);
+    this.ordered_varnames = ordered_varnames;
+  }
+}

--- a/frontend/src/models/TraceStep.js
+++ b/frontend/src/models/TraceStep.js
@@ -1,0 +1,22 @@
+import Variable from "./Variable";
+import StackFrame from "./StackFrame";
+import Utils from "../Utils";
+
+export default class TraceStep {
+  constructor({ event, exception_msg, func_name, line, globals, ordered_globals, heap, stack_to_render, stdout }) {
+    this.event = event;
+
+    if (event === "uncaught_exception") {
+      this.exceptionMessage = exception_msg;
+      return;
+    }
+
+    this.funcName = func_name;
+    this.line = line;
+    this.globals = globals;
+    this.orderedGlobals = ordered_globals;
+    this.heap = Utils.mapValues(Variable, heap);
+    this.stack = Utils.arrayOfType(StackFrame, stack_to_render);
+    this.stdout = stdout;
+  }
+}

--- a/frontend/src/models/Variable.js
+++ b/frontend/src/models/Variable.js
@@ -1,0 +1,28 @@
+import Utils from "../Utils";
+
+export default class Variable {
+  static get CTypes() {
+    return { ARRAY: "C_ARRAY", DATA: "C_DATA" };
+  }
+
+  constructor(data) {
+    const [ cType, address ] = data;
+    this.cType = cType;
+    this.address = address;
+    if (cType === Variable.CTypes.ARRAY) {
+      this.type = "array";
+      this.value = Utils.arrayOfType(Variable, data.slice(2));
+    } else {
+      this.type = data[2];
+      this.value = data[3];
+    }
+  }
+
+  isUninitialized() {
+    return this.value === "<UNINITIALIZED>";
+  }
+
+  isNull() {
+    return (this.type === "pointer" || this.type === "array") && this.value === "0x0";
+  }
+}


### PR DESCRIPTION
When we get a response from the API, having wrapper classes will be better than dealing with plain JavaScript objects.

Also adds a `Utils` class to store some useful methods.