### PR TITLE
update visualization with changes to heap variables

### DIFF
--- a/frontend/src/models/ProgramTrace.js
+++ b/frontend/src/models/ProgramTrace.js
@@ -6,6 +6,7 @@ export default class ProgramTrace {
     this.code = code;
     this.trace = Utils.arrayOfType(TraceStep, trace);
     this.traceIndex = 0;
+    this.prevVisualizedIndex = 0;
   }
 
   atStart() {
@@ -20,7 +21,8 @@ export default class ProgramTrace {
   }
 
   stepNext() {
-    if (!this.isDone()) this.traceIndex++;
+      this.prevVisualizedIndex = this.traceIndex;
+      if (!this.isDone()) this.traceIndex++;
 
     // let previousLine = this.getCurrentStep().line;
     // while (!this.isDone()) {
@@ -32,7 +34,8 @@ export default class ProgramTrace {
   }
 
   stepPrev() {
-    if (!this.atStart()) this.traceIndex--;
+      this.prevVisualizedIndex = this.traceIndex;
+      if (!this.atStart()) this.traceIndex--;
 
     // if (this.atStart()) return;
     // this.traceIndex--;
@@ -48,18 +51,20 @@ export default class ProgramTrace {
   }
 
   stepStart() {
-    this.traceIndex = 0;
+      this.prevVisualizedIndex = this.traceIndex;
+      this.traceIndex = 0;
   }
 
   stepEnd() {
+    this.prevVisualizedIndex = this.traceIndex;
     this.traceIndex = this.trace.length - 1;
     // while (this.getCurrentStep().line === this.trace[this.traceIndex - 1].line) {
     //   this.traceIndex--;
     // }
   }
 
-  getPreviousStep() {
-    return this.atStart() ? this.trace[this.traceIndex] : this.trace[this.traceIndex - 1];
+  getPreviouslyVisualizedStep() {
+    return this.trace[this.prevVisualizedIndex] || null;
   }
 
   getCurrentStep() {

--- a/frontend/src/visualization/VariableCard.jsx
+++ b/frontend/src/visualization/VariableCard.jsx
@@ -25,21 +25,10 @@ export default class VariableCard extends Component {
   constructor(props) {
     super(props);
     this.state = { ...VisualizationTool.getVariableCardDimensions(this.props.variable) };
-    if (this.props.variable.isFree()) {
-      VisualizationTool.clearRegisteredComponents();
-      this.props.updateVisualization();
-    }
   }
 
   componentWillReceiveProps({ variable }) {
-    if (variable.isFree() !== this.props.variable.isFree()) {
-      console.log("about to update due to freedom differences");
-        this.setState({highlight: false, ...VisualizationTool.getVariableCardDimensions(variable)},
-            () => {
-                VisualizationTool.clearRegisteredComponents();
-                this.props.updateVisualization();
-            });
-    } else if (variable.getValue() !== this.props.variable.getValue()) {
+    if (variable.getValue() !== this.props.variable.getValue()) {
       this.setState({ highlight: true, ...VisualizationTool.getVariableCardDimensions(variable) });
     } else {
       this.setState({ highlight: false, ...VisualizationTool.getVariableCardDimensions(variable) });

--- a/frontend/src/visualization/Visualization.jsx
+++ b/frontend/src/visualization/Visualization.jsx
@@ -26,7 +26,20 @@ export default class Visualization extends Component {
   }
 
   getHeapVariableNodes() {
+    const prevStep = this.props.trace.getPreviouslyVisualizedStep();
     const step = this.props.trace.getCurrentStep();
+    if (prevStep.getHeapVariables().length !== step.getHeapVariables().length) {
+      VisualizationTool.clearRegisteredComponents();
+    } else {
+      for (let i = 0; i < prevStep.getHeapVariables().length; i++) {
+        const prevElem = prevStep.getHeapVariables()[i];
+        const currElem = step.getHeapVariables()[i];
+        if (prevElem.getId() !== currElem.getId() || prevElem.isFree() !== currElem.isFree()) {
+          VisualizationTool.clearRegisteredComponents();
+          break;
+        }
+      }
+    }
     return step.getHeapVariables().map(v => {
       const dimensions = VisualizationTool.getVariableCardDimensions(v);
       return {


### PR DESCRIPTION
Ashley and Maria
- Free now auto-updates the visualization
- removing non-pointed-to nodes updates visualization
- going backwards (i.e. from freed to non-freed) also updates visualization
- changing what's pointed to also updates visualization (i.e. if the head moves from pointing to the first node to the second node, all the nodes shift up)

@knazir @ruechy how ok are you with how this handles dragging, cuz it's a little broken (but it was already broken)