### PR TITLE
Clear only heap variables when only the heap has been updated

### DIFF
--- a/frontend/src/utils/VisualizationTool.js
+++ b/frontend/src/utils/VisualizationTool.js
@@ -149,6 +149,17 @@ class VisualizationTool {
   static clearRegisteredComponents() {
     VisualizationTool.componentsByAddress = {};
   }
+
+  static clearHeapRegisteredComponents() {
+    const components = VisualizationTool.componentsByAddress;
+    VisualizationTool.clearRegisteredComponents();
+    for (const address in components) {
+      const variable = components[address].variable;
+      if (variable.stackFrameHash || variable.global) {
+        VisualizationTool.componentsByAddress[address] = components[address];
+      }
+    }
+  }
 }
 
 VisualizationTool.componentsByAddress = {};

--- a/frontend/src/visualization/Visualization.jsx
+++ b/frontend/src/visualization/Visualization.jsx
@@ -30,14 +30,14 @@ export default class Visualization extends Component {
     const prevStep = this.props.trace.getPreviouslyVisualizedStep();
     const step = this.props.trace.getCurrentStep();
     if (prevStep.getHeapVariables().length !== step.getHeapVariables().length) {
-      VisualizationTool.clearRegisteredComponents();
+      VisualizationTool.clearHeapRegisteredComponents();
       this.props.trace.prevVisualizedIndex = this.props.trace.traceIndex;
     } else {
       for (let i = 0; i < prevStep.getHeapVariables().length; i++) {
         const prevElem = prevStep.getHeapVariables()[i];
         const currElem = step.getHeapVariables()[i];
         if (prevElem.getId() !== currElem.getId() || prevElem.isFree() !== currElem.isFree()) {
-          VisualizationTool.clearRegisteredComponents();
+          VisualizationTool.clearHeapRegisteredComponents();
           this.props.trace.prevVisualizedIndex = this.props.trace.traceIndex;
           break;
         }


### PR DESCRIPTION
Current bug is that after an element is added (or removed) from the heap, we lose all information about the stack variables, breaking pass by reference (as then we just don't know where the reference points to). Now, we only clear all the registered components when what's displayed in the stack changes, and we clear the heap components when the heap changes.