### PR TITLE
handle crashes, auto-update when stack frames auto-expand

### DIFF
--- a/frontend/src/models/ProgramTrace.js
+++ b/frontend/src/models/ProgramTrace.js
@@ -82,6 +82,7 @@ export default class ProgramTrace {
 
   _setupPointerTargets() {
     this.trace.forEach(traceStep => {
+      if (traceStep.encounteredException()) return;
       const variables = traceStep.getAllVariables();
       variables.forEach(variable => {
         if (!variable.isPointer()) return;

--- a/frontend/src/models/TraceStep.js
+++ b/frontend/src/models/TraceStep.js
@@ -61,7 +61,7 @@ export default class TraceStep {
   _mapHeap(heap) {
     // need to create a "meta heap" to pass in to heap variables without being circular (not sure why though...)
     // note, no variables should be orphaned here as we check after all heaps are mapped (so we ignore the property)
-    const metaHeap = Utils.mapValues(Variable, heap);
+    const metaHeap = Utils.mapValues(Variable, heap, varData => new Variable(varData, null, false, heap));
     const result = Utils.mapValues(Variable, heap, varData => new Variable(varData, null, false, metaHeap));
     Object.entries(result).forEach(([varName, heapVar]) => heapVar.setName(varName));
     return result;

--- a/frontend/src/utils/VisualizationTool.js
+++ b/frontend/src/utils/VisualizationTool.js
@@ -116,7 +116,9 @@ class VisualizationTool {
   static registerComponents(components) {
     components.forEach(component => {
       const variable = component.props.variable;
-      if (!variable || VisualizationTool.componentsByAddress[variable.address]) return;
+      if (!variable) return;
+      const componentInfo = VisualizationTool.componentsByAddress[variable.address];
+      if (componentInfo && componentInfo.variable.getId() !== variable.getId()) return;
       const { x, y } = component.props;
       VisualizationTool.componentsByAddress[variable.address] = { x, y, variable, component };
     });


### PR DESCRIPTION
- when program crashes or has a memory error, the visualization no longer crashes
- all variables are initialized with a non-null heap, preventing visualization crashes on strings
- stack auto-updates, which requires calling forceUpdate twice (conditionally). I tried modifying it in setState, but it expands infinitely deeply; this approach only conditionally updates twice and does so exactly twice. Open to other suggestions :)