### PR TITLE
pointers don't hang around with freed memory

### DIFF
--- a/frontend/src/models/Variable.js
+++ b/frontend/src/models/Variable.js
@@ -51,7 +51,7 @@ export default class Variable {
   }
 
   getId() {
-    return `${this.toString()} ${this.address}`;
+    return `${this.name} ${this.address}`;
   }
 
   //////////// Property Querying ////////////


### PR DESCRIPTION
Freed memory components were not overwriting the unfreed components, leading to weird arrow bugs (e.g. on reverseLinkedList). Now, we just use the name of the variable and its address instead of the toString of the variable.