### PR TITLE
Add split line, titles, and guide lines directly to stage

### DIFF
--- a/frontend/src/components/DomCard.jsx
+++ b/frontend/src/components/DomCard.jsx
@@ -1,13 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { DomCard as VisualConstants } from "../utils/VisualConstants";
 
 export default class DomCard extends Component {
   static get propTypes() {
     return {
       title: PropTypes.string.isRequired,
-      splitTitle: PropTypes.bool,
-      secondTitle: PropTypes.string,
       titleStyle: PropTypes.object,
       style: PropTypes.object,
       bodyStyle: PropTypes.object,
@@ -20,32 +17,16 @@ export default class DomCard extends Component {
   }
 
   getTitle() {
-    if (this.props.splitTitle) {
-      return (
-        <div className="box-title split" style={this.props.titleStyle}>
-          <h3>{this.props.title}</h3>
-          <h3>{this.props.secondTitle}</h3>
-        </div>
-      );
-    } else {
-      return (
-        <div className="box-title" style={this.props.titleStyle}>
-          <h3 style={{ padding: 0 }}>{this.props.title}</h3>
-        </div>
-      );
-    }
-  }
-
-  getSplitLine() {
-    const height = this.props.height + VisualConstants.TITLE_HEIGHT;
-    if (this.props.splitTitle) return <div className="split-line" style={{ height }}/>;
-    return <div/>;
+    return (
+      <div className="box-title" style={this.props.titleStyle}>
+        <h3 style={{ padding: 0 }}>{this.props.title}</h3>
+      </div>
+    );
   }
 
   render() {
     return (
       <div style={this.props.style}>
-        {this.getSplitLine()}
         {this.getTitle()}
         <div className="box-content" style={this.props.bodyStyle}>
           {this.props.children}

--- a/frontend/src/utils/VisualConstants.js
+++ b/frontend/src/utils/VisualConstants.js
@@ -82,6 +82,19 @@ module.exports = {
   },
   Visualization: {
     PADDING: 70,
-    KONVA_PADDING: 2
+    KONVA_PADDING: 2,
+    SPLIT_LINE: {
+      COLOR: "#e2e2e2",
+      WIDTH: 1
+    },
+    STAGE_Y_OFFSET: 42,
+    TITLE_Y_OFFSET: 10,
+    TITLE_UNDERLINE_Y_OFFSET: 35,
+    FONT: {
+      SIZE: 17,
+      FAMILY: "Menlo, monospace",
+      STYLE: "bold",
+      ALIGNMENT: "center"
+    }
   }
 };


### PR DESCRIPTION
Moved the split lines and stack/heap titles to the actual stage so that we can enable horizontal dragging.