### PR TITLE
Only allow highlighting/clicking on line numbers with valid trace step

### DIFF
--- a/frontend/src/editor/Ide.jsx
+++ b/frontend/src/editor/Ide.jsx
@@ -207,7 +207,11 @@ export default class Ide extends Component {
   //////////// DOM Manipulation ////////////
 
   setupVisualizingDom() {
-    document.querySelectorAll(".CodeMirror-gutter-elt").forEach(element => element.classList.remove("unclickable"));
+    document.querySelectorAll(".CodeMirror-gutter-elt").forEach(element => {
+      const lineNumber = Number(element.textContent);
+      if (this.props.trace.isValidLine(lineNumber)) element.classList.remove("unclickable");
+      else element.classList.add("unclickable");
+    });
     const codeMirrorLines = document.querySelector(".CodeMirror-lines");
     if (codeMirrorLines) codeMirrorLines.classList.add("disabled");
   }

--- a/frontend/src/models/ProgramTrace.js
+++ b/frontend/src/models/ProgramTrace.js
@@ -11,9 +11,10 @@ export default class ProgramTrace {
       this._setupPointerTargets();
       this._setupActiveStackFrames();
       this._setupChangedStackFrames();
-    }
-    if (this.trace[this.trace.length - 1].encounteredException() && this.trace.length > 1) {
-      this.trace[this.trace.length - 1].loadStep(this.trace[this.trace.length - 2]);
+      this.lineNumbers = this._getValidLineNumbers();
+      if (this.trace[this.trace.length - 1].encounteredException() && this.trace.length > 1) {
+        this.trace[this.trace.length - 1].loadStep(this.trace[this.trace.length - 2]);
+      }
     }
   }
 
@@ -80,6 +81,10 @@ export default class ProgramTrace {
     return this.traceIndex === this.trace.length - 1;
   }
 
+  isValidLine(lineNumber) {
+    return this.lineNumbers.has(lineNumber);
+  }
+
   //////////// Mutator Methods ////////////
 
   setStackFrameExpanded(stackFrame, expanded) {
@@ -140,5 +145,11 @@ export default class ProgramTrace {
         if (!stackFrame.expanded && shouldExpand) stackFrame.setExpanded(true);
       }
     }
+  }
+
+  _getValidLineNumbers() {
+    const lineNumbers = new Set();
+    this.trace.forEach(step => lineNumbers.add(step.line));
+    return lineNumbers;
   }
 }


### PR DESCRIPTION
Now lines that aren't associated with a valid trace step will not be clickable or highlight on hover.