### PR TITLE
Keep `node_modules` generated by the npm inside the image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - '${BACKEND_PORT:-3000}:3000'
     volumes:
       - ./backend:/app
+      - /app/node_modules
       - /tmp:/tmp
       - /var/run/docker.sock:/var/run/docker.sock
     environment:


### PR DESCRIPTION
`./backend:/app` volume mapping for the `backend` image will shadow the `node_modules` folder that is populated by the `npm install` executed when the `backend` image is prepared.

This creates a rather confusing behavior, when the image setup log shows that the packages are installed, and yet, the next step of running `nodemon` or `ts-node` fails.

I guess if `node_modules` is populated in the original tree, this issue is obscured.  But it seems broken, and will break anyone trying to run `./localdev.sh up` after a `git clone`.